### PR TITLE
update broken 'scuttlebot' link in the header

### DIFF
--- a/partials.js
+++ b/partials.js
@@ -36,7 +36,7 @@ module.exports.topnav = function (opts) {
     <div id="topnav-inner">
       ${item('/', 'Home', 'SSBC')}
       ${item('/patchwork', 'Patchwork', 'Social Messaging App')}
-      ${item('/docs/scuttlebot', 'Scuttlebot', 'P2P Log Store')}
+      ${item('/docs/scuttlebot/install.html', 'Scuttlebot', 'P2P Log Store')}
       ${item('/docs', 'Documentation', 'APIs, Articles')}
     </div>
   </div>`

--- a/partials.js
+++ b/partials.js
@@ -36,7 +36,7 @@ module.exports.topnav = function (opts) {
     <div id="topnav-inner">
       ${item('/', 'Home', 'SSBC')}
       ${item('/patchwork', 'Patchwork', 'Social Messaging App')}
-      ${item('/scuttlebot', 'Scuttlebot', 'P2P Log Store')}
+      ${item('/docs/scuttlebot', 'Scuttlebot', 'P2P Log Store')}
       ${item('/docs', 'Documentation', 'APIs, Articles')}
     </div>
   </div>`


### PR DESCRIPTION
there doesn't seem to be a '/docs/scuttlebot' page itself, so that is also a missing page, that shouldn't be linked to